### PR TITLE
feat: event discovery and RSVP flow with student dashboard

### DIFF
--- a/backend/app/routes/events.py
+++ b/backend/app/routes/events.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, jsonify, request
+from datetime import datetime
 from app import db
-from app.models import Event, Organization, User
+from app.models import Event, Organization, User, EventAttendee
 
 events_bp = Blueprint("events", __name__)
 
@@ -72,3 +73,63 @@ def reject_event(event_id):
     db.session.commit()
 
     return jsonify({"message": "Event rejected", "id": event.id, "approval_status": event.approval_status})
+
+
+@events_bp.get("/api/events/upcoming")
+def get_upcoming_events():
+    # only return events that are approved and haven't started yet
+    now = datetime.utcnow()
+    upcoming = Event.query.filter(
+        Event.approval_status == "Approved",
+        Event.start_time > now
+    ).order_by(Event.start_time.asc()).all()
+
+    return jsonify([
+        {
+            "id": e.id,
+            "title": e.title,
+            "description": e.description,
+            "start_time": e.start_time.isoformat() if e.start_time else None,
+            "location": e.location,
+            "attendee_count": EventAttendee.query.filter_by(event_id=e.id).count(),
+        }
+        for e in upcoming
+    ])
+
+
+@events_bp.post("/api/events/<int:event_id>/rsvp")
+def rsvp_to_event(event_id):
+    # temporary: hardcoded to James Wilson until auth is built
+    current_user_id = 2
+
+    event = Event.query.get(event_id)
+    if not event:
+        return jsonify({"error": "Event not found"}), 404
+
+    # check if this user already RSVPed to prevent RSVPing again
+    existing = EventAttendee.query.filter_by(
+        event_id=event_id,
+        user_id=current_user_id
+    ).first()
+
+    if existing:
+        return jsonify({"error": "Already RSVPed to this event"}), 409
+
+    new_rsvp = EventAttendee(event_id=event_id, user_id=current_user_id)
+    db.session.add(new_rsvp)
+    db.session.commit()
+
+    return jsonify({"message": "RSVP confirmed"}), 200
+
+
+@events_bp.get("/api/events/<int:event_id>/rsvp/status")
+def get_rsvp_status(event_id):
+    # temporary: hardcoded to James Wilson until auth is built
+    current_user_id = 2
+
+    existing = EventAttendee.query.filter_by(
+        event_id=event_id,
+        user_id=current_user_id
+    ).first()
+
+    return jsonify({"attending": existing is not None})

--- a/backend/app/routes/orgs.py
+++ b/backend/app/routes/orgs.py
@@ -1,7 +1,9 @@
 from flask import Blueprint, jsonify
-from app.models import Organization
+from app import db
+from app.models import Organization, OrgMember
 
 organizations = Blueprint("orgs", __name__)
+
 
 @organizations.get("/api/orgs/")
 def get_organizations():
@@ -17,3 +19,41 @@ def get_organizations():
         }
         for org in orgs
     ])
+
+
+@organizations.get("/api/orgs/<int:org_id>/join/status")
+def get_join_status(org_id):
+    # temporary: hardcoded to James Wilson until auth is built
+    current_user_id = 2
+
+    existing = OrgMember.query.filter_by(
+        org_id=org_id,
+        user_id=current_user_id
+    ).first()
+
+    return jsonify({"joined": existing is not None})
+
+
+@organizations.post("/api/orgs/<int:org_id>/join")
+def join_org(org_id):
+    # temporary: hardcoded to James Wilson until auth is built
+    current_user_id = 2
+
+    org = Organization.query.get(org_id)
+    if not org:
+        return jsonify({"error": "Organization not found"}), 404
+
+    # prevent duplicate memberships
+    existing = OrgMember.query.filter_by(
+        org_id=org_id,
+        user_id=current_user_id
+    ).first()
+
+    if existing:
+        return jsonify({"error": "Already a member"}), 409
+
+    new_member = OrgMember(org_id=org_id, user_id=current_user_id)
+    db.session.add(new_member)
+    db.session.commit()
+
+    return jsonify({"message": "Joined successfully"}), 200

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,19 @@
 import { Routes, Route } from "react-router-dom";
 import HomePage from "./pages/HomePage";
+import StudentPage from "./pages/StudentPage";
 import OrgsPage from "./pages/OrgsPage";
 import OrgDetailPage from "./pages/OrgDetailPage";
+import EventsPage from "./pages/EventsPage";
 import AdminDashboard from "./components/AdminDashboard";
 
 function App() {
     return (
         <Routes>
             <Route path="/" element={<HomePage />} />
+            <Route path="/student" element={<StudentPage />} />
             <Route path="/orgs" element={<OrgsPage />} />
             <Route path="/orgs/:id" element={<OrgDetailPage />} />
+            <Route path="/events" element={<EventsPage />} />
             <Route path="/admin" element={<AdminDashboard />} />
         </Routes>
     );

--- a/frontend/src/components/OrgCard.tsx
+++ b/frontend/src/components/OrgCard.tsx
@@ -1,6 +1,7 @@
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
-interface OrgCardDetails{
+interface OrgCardDetails {
     id: number;
     name: string;
     acronym: string;
@@ -8,15 +9,67 @@ interface OrgCardDetails{
 }
 
 const OrgCard = ({ id, name, acronym, description }: OrgCardDetails) => {
+    const [joined, setJoined] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    // check if the user already joined so the button shows attending
+    useEffect(() => {
+        fetch(`/api/orgs/${id}/join/status`)
+            .then((res) => res.json())
+            .then((data) => setJoined(data.joined))
+            .catch(() => {});
+    }, [id]);
+
+    const handleJoin = async (e: React.MouseEvent) => {
+        e.preventDefault();
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/orgs/${id}/join`, { method: "POST" });
+            if (res.ok) {
+                setJoined(true);
+            }
+        } catch {
+            // silently fail for now
+        } finally {
+            setLoading(false);
+        }
+    };
+
     return (
-    <Link to={`/orgs/${id}`} style={{ textDecoration: "none", color: "inherit" }}>
-        <div>
-            <h2>{name}</h2>
-            <p>{acronym}</p>
-            <p>{description}</p>
-        </div>
-    </Link>
-);
+        <Link to={`/orgs/${id}`} style={{ textDecoration: "none", color: "inherit" }}>
+            <div style={{ border: "1px solid var(--color-border)", borderRadius: "8px", padding: "16px", height: "100%", boxSizing: "border-box" }}>
+                {/* logo placeholder */}
+                <div style={{ width: "40px", height: "40px", background: "var(--color-skeleton)", borderRadius: "4px", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "0.7em", color: "var(--color-text-secondary)", marginBottom: "12px" }}>
+                    Logo
+                </div>
+
+                <h3 style={{ margin: "0 0 6px", fontSize: "1em", fontWeight: "600" }}>{name}</h3>
+                <p style={{ margin: "0 0 12px", fontSize: "0.82em", color: "var(--color-text-secondary)", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+                    {description}
+                </p>
+
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "auto" }}>
+                    <span style={{ fontSize: "0.8em", color: "var(--color-text-secondary)" }}>{acronym}</span>
+                    <button
+                        onClick={handleJoin}
+                        disabled={joined || loading}
+                        style={{
+                            padding: "5px 14px",
+                            fontSize: "0.82em",
+                            backgroundColor: joined ? "#6c757d" : "var(--color-bg-elevated)",
+                            color: joined ? "white" : "var(--color-text)",
+                            border: "1px solid var(--color-border)",
+                            borderRadius: "6px",
+                            cursor: joined ? "default" : "pointer",
+                            fontWeight: "600",
+                        }}
+                    >
+                        {joined ? "✓ Joined" : loading ? "..." : "Join"}
+                    </button>
+                </div>
+            </div>
+        </Link>
+    );
 };
 
 export default OrgCard;

--- a/frontend/src/components/UpcomingEventCard.tsx
+++ b/frontend/src/components/UpcomingEventCard.tsx
@@ -20,7 +20,8 @@ function formatDateTime(iso: string | null): string {
     });
 }
 
-const UpcomingEventCard = ({ id, title, description, start_time, location: _location, attendee_count }: UpcomingEventCardProps) => {
+const UpcomingEventCard = (props: UpcomingEventCardProps) => {
+    const { id, title, description, start_time, attendee_count } = props;
     const [attending, setAttending] = useState(false);
     const [toast, setToast] = useState<{ message: string; success: boolean } | null>(null);
     const [loading, setLoading] = useState(false);

--- a/frontend/src/components/UpcomingEventCard.tsx
+++ b/frontend/src/components/UpcomingEventCard.tsx
@@ -20,12 +20,11 @@ function formatDateTime(iso: string | null): string {
     });
 }
 
-const UpcomingEventCard = ({ id, title, description, start_time, location, attendee_count }: UpcomingEventCardProps) => {
+const UpcomingEventCard = ({ id, title, description, start_time, location: _location, attendee_count }: UpcomingEventCardProps) => {
     const [attending, setAttending] = useState(false);
     const [toast, setToast] = useState<{ message: string; success: boolean } | null>(null);
     const [loading, setLoading] = useState(false);
 
-    // check on load if the user already RSVPed so the button reflects the correct state
     useEffect(() => {
         fetch(`/api/events/${id}/rsvp/status`)
             .then((res) => res.json())
@@ -57,7 +56,6 @@ const UpcomingEventCard = ({ id, title, description, start_time, location, atten
 
     return (
         <div style={{ border: "1px solid var(--color-border)", borderRadius: "8px", overflow: "hidden" }}>
-            {/* event image placeholder */}
             <div style={{ background: "var(--color-skeleton)", height: "150px", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "0.85em", color: "var(--color-text-secondary)" }}>
                 Event Image
             </div>

--- a/frontend/src/components/UpcomingEventCard.tsx
+++ b/frontend/src/components/UpcomingEventCard.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect } from "react";
+
+interface UpcomingEventCardProps {
+    id: number;
+    title: string;
+    description: string | null;
+    start_time: string | null;
+    location: string | null;
+    attendee_count: number;
+}
+
+function formatDateTime(iso: string | null): string {
+    if (!iso) return "TBD";
+    return new Date(iso).toLocaleString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+    });
+}
+
+const UpcomingEventCard = ({ id, title, description, start_time, location, attendee_count }: UpcomingEventCardProps) => {
+    const [attending, setAttending] = useState(false);
+    const [toast, setToast] = useState<{ message: string; success: boolean } | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    // check on load if the user already RSVPed so the button reflects the correct state
+    useEffect(() => {
+        fetch(`/api/events/${id}/rsvp/status`)
+            .then((res) => res.json())
+            .then((data) => setAttending(data.attending))
+            .catch(() => {});
+    }, [id]);
+
+    const showToast = (message: string, success: boolean) => {
+        setToast({ message, success });
+        setTimeout(() => setToast(null), 3000);
+    };
+
+    const handleRsvp = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/events/${id}/rsvp`, { method: "POST" });
+            if (res.ok) {
+                setAttending(true);
+                showToast("RSVP Confirmed!", true);
+            } else {
+                showToast("Failed to RSVP, please try again", false);
+            }
+        } catch {
+            showToast("Failed to RSVP, please try again", false);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div style={{ border: "1px solid var(--color-border)", borderRadius: "8px", overflow: "hidden" }}>
+            {/* event image placeholder */}
+            <div style={{ background: "var(--color-skeleton)", height: "150px", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "0.85em", color: "var(--color-text-secondary)" }}>
+                Event Image
+            </div>
+
+            <div style={{ padding: "14px" }}>
+                <p style={{ margin: "0 0 6px", fontSize: "0.8em", color: "var(--color-text-secondary)" }}>
+                    📅 {formatDateTime(start_time)}
+                </p>
+
+                <h3 style={{ margin: "0 0 6px", fontSize: "1em", fontWeight: "600" }}>{title}</h3>
+
+                {description && (
+                    <p style={{ margin: "0 0 10px", fontSize: "0.82em", color: "var(--color-text-secondary)", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+                        {description}
+                    </p>
+                )}
+
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: "10px" }}>
+                    <span style={{ fontSize: "0.8em", color: "var(--color-text-secondary)" }}>
+                        👥 {attendee_count} attending
+                    </span>
+                    <button
+                        onClick={handleRsvp}
+                        disabled={attending || loading}
+                        style={{
+                            padding: "6px 14px",
+                            borderRadius: "6px",
+                            cursor: attending ? "default" : "pointer",
+                            backgroundColor: attending ? "#6c757d" : "var(--color-bg-elevated)",
+                            color: attending ? "white" : "var(--color-text)",
+                            fontWeight: "600",
+                            fontSize: "0.82em",
+                            border: "1px solid var(--color-border)",
+                        }}
+                    >
+                        {attending ? "✓ Attending" : loading ? "..." : "RSVP"}
+                    </button>
+                </div>
+            </div>
+
+            {toast && (
+                <div style={{
+                    position: "fixed",
+                    bottom: "24px",
+                    right: "24px",
+                    padding: "12px 20px",
+                    borderRadius: "8px",
+                    backgroundColor: toast.success ? "#28a745" : "#dc3545",
+                    color: "white",
+                    fontWeight: "bold",
+                    zIndex: 1000,
+                    boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+                    fontSize: "0.9em",
+                }}>
+                    {toast.message}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default UpcomingEventCard;

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import UpcomingEventCard from "../components/UpcomingEventCard";
+
+interface UpcomingEvent {
+    id: number;
+    title: string;
+    description: string | null;
+    start_time: string | null;
+    location: string | null;
+    attendee_count: number;
+}
+
+const EventsPage = () => {
+    const [events, setEvents] = useState<UpcomingEvent[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        fetch("/api/events/upcoming")
+            .then((res) => res.json())
+            .then((data) => {
+                setEvents(data);
+                setLoading(false);
+            })
+            .catch(() => setLoading(false));
+    }, []);
+
+    if (loading) {
+        return (
+            <div style={{ padding: "20px" }}>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "16px" }}>
+                    {[1, 2, 3].map((n) => (
+                        <div key={n} style={{ background: "var(--color-skeleton)", height: "280px", borderRadius: "8px" }} />
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div style={{ padding: "20px" }}>
+            <Link to="/" style={{ fontSize: "0.9em" }}>&larr; Back to Home</Link>
+            <h1>Upcoming Events</h1>
+            <p style={{ color: "var(--color-text-secondary)", marginBottom: "24px" }}>
+                Don't miss out on exciting campus events
+            </p>
+
+            {events.length === 0 ? (
+                <p style={{ color: "var(--color-text-secondary)" }}>No upcoming events right now — check back soon!</p>
+            ) : (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "16px" }}>
+                    {events.map((event) => (
+                        <UpcomingEventCard
+                            key={event.id}
+                            id={event.id}
+                            title={event.title}
+                            description={event.description}
+                            start_time={event.start_time}
+                            location={event.location}
+                            attendee_count={event.attendee_count}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default EventsPage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -6,10 +6,10 @@ const HomePage = () => {
             <h1>ECS Command Center</h1>
             <p style={{ color: "var(--color-text-secondary)" }}>Welcome! Select a section below to get started.</p>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "16px", marginTop: "24px" }}>
-                <Link to="/orgs" style={{ textDecoration: "none", color: "inherit" }}>
+                <Link to="/student" style={{ textDecoration: "none", color: "inherit" }}>
                     <div style={{ border: "1px solid var(--color-border)", borderRadius: "8px", padding: "24px" }}>
-                        <h2 style={{ marginTop: 0 }}>Organizations</h2>
-                        <p style={{ color: "var(--color-text-secondary)" }}>Browse active student organizations</p>
+                        <h2 style={{ marginTop: 0 }}>Student Dashboard</h2>
+                        <p style={{ color: "var(--color-text-secondary)" }}>Browse organizations and upcoming events</p>
                     </div>
                 </Link>
                 <Link to="/admin" style={{ textDecoration: "none", color: "inherit" }}>

--- a/frontend/src/pages/StudentPage.tsx
+++ b/frontend/src/pages/StudentPage.tsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import OrgCard from "../components/OrgCard";
+import UpcomingEventCard from "../components/UpcomingEventCard";
+
+interface Org {
+    id: number;
+    name: string;
+    acronym: string;
+    description: string;
+}
+
+interface UpcomingEvent {
+    id: number;
+    title: string;
+    description: string | null;
+    start_time: string | null;
+    location: string | null;
+    attendee_count: number;
+}
+
+const StudentPage = () => {
+    const [orgs, setOrgs] = useState<Org[]>([]);
+    const [events, setEvents] = useState<UpcomingEvent[]>([]);
+    const [orgsLoading, setOrgsLoading] = useState(true);
+    const [eventsLoading, setEventsLoading] = useState(true);
+    const [search, setSearch] = useState("");
+
+    useEffect(() => {
+        fetch("/api/orgs/")
+            .then((res) => res.json())
+            .then((data) => {
+                setOrgs(data);
+                setOrgsLoading(false);
+            })
+            .catch(() => setOrgsLoading(false));
+
+        fetch("/api/events/upcoming")
+            .then((res) => res.json())
+            .then((data) => {
+                setEvents(data);
+                setEventsLoading(false);
+            })
+            .catch(() => setEventsLoading(false));
+    }, []);
+
+    const filteredOrgs = orgs.filter(
+        (org) =>
+            org.name.toLowerCase().includes(search.toLowerCase()) ||
+            org.acronym.toLowerCase().includes(search.toLowerCase())
+    );
+
+    return (
+        <div style={{ padding: "24px", maxWidth: "1100px", margin: "0 auto" }}>
+            <Link to="/" style={{ fontSize: "0.85em" }}>&larr; Back to Home</Link>
+
+            {/* Organizations Section */}
+            <div style={{ marginBottom: "48px", marginTop: "16px" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+                    <div>
+                        <h2 style={{ margin: 0, fontSize: "1.6em" }}>Organizations</h2>
+                        <p style={{ color: "var(--color-text-secondary)", margin: "4px 0 12px", fontSize: "0.9em" }}>
+                            Discover and join student organizations on campus
+                        </p>
+                    </div>
+                    <Link to="/orgs" style={{ fontSize: "0.85em", border: "1px solid var(--color-border)", padding: "6px 12px", borderRadius: "6px", textDecoration: "none", color: "var(--color-text)" }}>
+                        View All Orgs
+                    </Link>
+                </div>
+
+                <input
+                    type="text"
+                    placeholder="Search organizations..."
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    style={{ marginBottom: "16px", padding: "8px 12px", width: "100%", borderRadius: "6px", boxSizing: "border-box", fontSize: "0.9em" }}
+                />
+
+                {orgsLoading ? (
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "16px" }}>
+                        {[1, 2, 3, 4, 5, 6].map((n) => (
+                            <div key={n} style={{ background: "var(--color-skeleton)", height: "140px", borderRadius: "8px" }} />
+                        ))}
+                    </div>
+                ) : (
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "16px" }}>
+                        {filteredOrgs.slice(0, 6).map((org) => (
+                            <OrgCard
+                                key={org.id}
+                                id={org.id}
+                                name={org.name}
+                                acronym={org.acronym}
+                                description={org.description}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* Upcoming Events Section */}
+            <div>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+                    <div>
+                        <h2 style={{ margin: 0, fontSize: "1.6em" }}>Upcoming Events</h2>
+                        <p style={{ color: "var(--color-text-secondary)", margin: "4px 0 16px", fontSize: "0.9em" }}>
+                            Don't miss out on exciting campus events
+                        </p>
+                    </div>
+                    <Link to="/events" style={{ fontSize: "0.85em", border: "1px solid var(--color-border)", padding: "6px 12px", borderRadius: "6px", textDecoration: "none", color: "var(--color-text)" }}>
+                        View All Events
+                    </Link>
+                </div>
+
+                {eventsLoading ? (
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "16px" }}>
+                        {[1, 2, 3].map((n) => (
+                            <div key={n} style={{ background: "var(--color-skeleton)", height: "280px", borderRadius: "8px" }} />
+                        ))}
+                    </div>
+                ) : events.length === 0 ? (
+                    <p style={{ color: "var(--color-text-secondary)", fontSize: "0.9em" }}>No upcoming events right now — check back soon!</p>
+                ) : (
+                    <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "16px" }}>
+                        {events.slice(0, 3).map((event) => (
+                            <UpcomingEventCard
+                                key={event.id}
+                                id={event.id}
+                                title={event.title}
+                                description={event.description}
+                                start_time={event.start_time}
+                                location={event.location}
+                                attendee_count={event.attendee_count}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+
+        </div>
+    );
+};
+
+export default StudentPage;


### PR DESCRIPTION
Closes #24

## What was built

### Backend
- Added `GET /api/events/upcoming` — returns only future approved events with attendee count, separate from the existing admin events route to avoid conflicts
- Added `POST /api/events/:id/rsvp` — creates an RSVP record for the current user, prevents duplicate RSVPs with a 409 response
- Added `GET /api/events/:id/rsvp/status` — checks if the current user has already RSVPed so the button state persists across page refreshes
- Added `POST /api/orgs/:id/join` and `GET /api/orgs/:id/join/status` — same pattern for org membership

### Frontend
- Created `UpcomingEventCard.tsx` — student-facing event card with RSVP button, success/error toast notifications, and persistent attending state
- Created `EventsPage.tsx` — full upcoming events page at `/events`
- Created `StudentPage.tsx` — unified student dashboard at `/student` showing both organizations and upcoming events on one page, matching the wireframe layout
- Updated `HomePage.tsx` — restored teammate's original nav layout, added Student Dashboard card linking to `/student`
- Updated `OrgCard.tsx` — restyled to match wireframe, added persistent Join button backed by the database
- Updated `App.tsx` — added `/student` and `/events` routes

## Notes
- RSVP and Join routes are temporarily hardcoded to user_id 2 (James Wilson) until authentication is implemented
- The existing `GET /api/events/` and admin routes were not modified to avoid breaking the admin dashboard